### PR TITLE
feat: Add meta units filter to lineup page

### DIFF
--- a/src/app/(protected)/lineups/[name]/page.tsx
+++ b/src/app/(protected)/lineups/[name]/page.tsx
@@ -99,6 +99,7 @@ const Page: React.FC = () => {
     heroic_checked: true,
     golden_checked: true,
     other_checked: true,
+    meta_units_only: true,
   });
 
   const units = useMemo(() => {
@@ -111,6 +112,7 @@ const Page: React.FC = () => {
     const chivalric_era = filterUnits.chivalric_checked ? greenUnits : [];
     const rustic_era = filterUnits.rustic_checked ? greyUnits : [];
     const others_unit = filterUnits.other_checked ? others : [];
+
     return [
       ...golden_era,
       ...heroic_era,
@@ -283,6 +285,16 @@ const Page: React.FC = () => {
             <AccordionTrigger className="px-6">Filtry</AccordionTrigger>
             <AccordionContent className="flex justify-around p-2 flex-wrap">
               <CheckboxItem
+                checked={filterUnits.meta_units_only}
+                label="Tylko meta jednostki"
+                onChange={() =>
+                  setFilterUnits((prev) => ({
+                    ...prev,
+                    meta_units_only: !prev.meta_units_only,
+                  }))
+                }
+              />
+              <CheckboxItem
                 checked={filterUnits.golden_checked}
                 label="Epoka Złota"
                 onChange={() =>
@@ -369,7 +381,11 @@ const Page: React.FC = () => {
               weapons={weapons}
               key={index}
               index={index}
-              units={units}
+              units={
+                filterUnits.meta_units_only
+                  ? units.filter((e) => e.value > 7)
+                  : units
+              }
               data={e}
               onEdit={handleEdit}
             />


### PR DESCRIPTION
This commit adds a new checkbox item to the lineup page that allows users to filter units based on whether they are meta units or not. When the "Tylko meta jednostki" checkbox is checked, only units with a value greater than 7 will be displayed. This feature improves the user experience by providing a more focused view of the lineup units.

Based on recent user commits and repository commits, it appears that there have been multiple refactorings and feature additions related to the autocompleter component, including lazy loading for images and improved autocompletion.